### PR TITLE
Add basic TeamCity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ go get github.com/ozonru/dtrack-audit/cmd/dtrack-audit
 * Async and sync modes. In async mode dtrack-audit simply sends SBOM file to DTrack API (like cURL but *in much more comfortable way*). Sync mode means: upload SBOM file, wait for the scan result, show it and exit with non-zero code. So you can break corresponding CI/CD job to make developers pay attention to findings
 * You can filter the results. With Sync mode enabled show result and fail an audit **if the results include a vulnerability with a severity of specified level or higher**. Severity levels are: critical, high, medium, low, info, unassigned
 * Auto creation of projects. With this feautre you can configure SCA (with dtrack-audit) step globally for your CI/CD and it will create project, e.g. with name from environment variable like `$CI_PROJECT_NAME`. So you don't need to configure it manually for each project
+* Support for TeamCity CI output. You can use `-T` flag to enable JSON output. After that, activate the [Golang build feature](https://www.jetbrains.com/help/teamcity/golang.html).
 
 ### Sample output
 

--- a/cmd/dtrack-audit/main.go
+++ b/cmd/dtrack-audit/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"github.com/ozonru/dtrack-audit/internal/dtrack"
@@ -10,15 +11,33 @@ import (
 	"time"
 )
 
+type TeamCityMsg struct {
+	Time    time.Time
+	Action  string
+	Package string
+	Test    string
+	Output  string
+}
+
+var packageName = "github.com/ozonru/dtrack-audit/cmd/dtrack-audit"
+var testName = "TestVulnerabilities"
+
 func checkError(e error) {
 	if e != nil {
 		log.Fatal(e)
 	}
 }
 
+func printTeamCityMsg(action, output string) {
+	msg := TeamCityMsg{time.Now(), action, packageName, testName, output}
+	jsonData, err := json.Marshal(msg)
+	checkError(err)
+	fmt.Println(string(jsonData))
+}
+
 func main() {
 	var inputFileName, projectId, apiKey, apiUrl, severityFilter, projectName, projectVersion string
-	var syncMode, autoCreateProject bool
+	var syncMode, autoCreateProject, useTeamCityOutput bool
 	var uploadResult dtrack.UploadResult
 	var timeout int
 
@@ -36,6 +55,7 @@ func main() {
 	}
 
 	autoCreateProject, err = strconv.ParseBool(os.Getenv("DTRACK_AUTO_CREATE_PROJECT"))
+	useTeamCityOutput, err = strconv.ParseBool(os.Getenv("DTRACK_TEAMCITY_OUTPUT"))
 
 	if err != nil {
 		autoCreateProject = false
@@ -50,6 +70,7 @@ func main() {
 	flag.StringVar(&severityFilter, "g", os.Getenv("DTRACK_SEVERITY_FILTER"), "With Sync mode enabled show result and fail an audit if the results include a vulnerability with a severity of specified level or higher. Severity levels are: critical, high, medium, low, info, unassigned. Environment variable is DTRACK_SEVERITY_FILTER")
 	flag.BoolVar(&syncMode, "s", syncMode, "Sync mode enabled. That means: upload SBOM file, wait for scan result, show it and exit with non-zero code. Environment variable is DTRACK_SYNC_MODE")
 	flag.BoolVar(&autoCreateProject, "a", autoCreateProject, "Auto create project with projectName if it does not exist. Environment variable is DTRACK_AUTO_CREATE_PROJECT")
+	flag.BoolVar(&useTeamCityOutput, "T", useTeamCityOutput, "Use TeamCity output. Environment variable is DTRACK_TEAMCITY_OUTPUT")
 	flag.IntVar(&timeout, "t", 25, "Max timeout in second for polling API for project findings")
 	flag.Parse()
 
@@ -78,18 +99,39 @@ func main() {
 	}
 
 	if uploadResult.Token != "" && syncMode {
+		if useTeamCityOutput {
+			printTeamCityMsg("run", "")
+		}
 		err := apiClient.PollTokenBeingProcessed(uploadResult.Token, time.After(time.Duration(timeout)*time.Second))
 		checkError(err)
 		findings, err := apiClient.GetFindings(projectId, severityFilter)
 		checkError(err)
 		if len(findings) > 0 {
+			var vulnMsg []string
 			fmt.Printf("%d vulnerabilities found!\n\n", len(findings))
 			for _, f := range findings {
-				fmt.Printf(" > %s: %s\n", f.Vuln.Severity, f.Vuln.Title)
-				fmt.Printf("   Component: %s %s\n", f.Comp.Name, f.Comp.Version)
-				fmt.Printf("   More info: %s\n\n", apiClient.GetVulnViewUrl(f.Vuln))
+				vulnMsg = append(
+					vulnMsg,
+					fmt.Sprintf(" > %s: %s\n", f.Vuln.Severity, f.Vuln.Title),
+					fmt.Sprintf("   Component: %s %s\n", f.Comp.Name, f.Comp.Version),
+					fmt.Sprintf("   More info: %s\n\n", apiClient.GetVulnViewUrl(f.Vuln)),
+				)
+			}
+			for _, msg := range vulnMsg {
+				if useTeamCityOutput {
+					printTeamCityMsg("output", msg)
+				} else {
+					fmt.Print(msg)
+				}
+			}
+			if useTeamCityOutput {
+				printTeamCityMsg("fail", "")
 			}
 			os.Exit(1)
 		}
+		if useTeamCityOutput {
+			printTeamCityMsg("pass", "")
+		}
 	}
 }
+


### PR DESCRIPTION
I created a basic support for TeamCity. It allows you to output audit results in JSON format, which TeamCity can recognise as test results. 

![image](https://user-images.githubusercontent.com/37303331/102228450-c6536680-3efb-11eb-8a34-c9d248e2d4ac.png)

![image](https://user-images.githubusercontent.com/37303331/102229135-7f19a580-3efc-11eb-8f91-72f2e0f56c35.png)
